### PR TITLE
Se corrige llamada recursiva de args.TimeFrame

### DIFF
--- a/args/arguments.go
+++ b/args/arguments.go
@@ -189,7 +189,7 @@ func Timeframe(val string) Argument {
 //
 // Accepts: 1, 5, 15, 60, 240, 1440 or 10080 as strings.
 func TimeFrame(val string) Argument {
-	return TimeFrame(val)
+	return Timeframe(val)
 }
 
 // Price is an argument of a request.


### PR DESCRIPTION
Se corrige bug en el metodo `args.TimeFrame` que se invocaba a si mismo quedando en un loop.